### PR TITLE
Fixed aside menu for big screen

### DIFF
--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -359,9 +359,9 @@ details li.feature {
 aside {
 	flex: 1;
 	font-size: 85%;
-	align-self: flex-end;
+	align-self: flex-start;
 	position: sticky;
-	bottom: 0;
+	top: 0;
 
 	.caution {
 		padding: 1em;


### PR DESCRIPTION
I find the position of the side menu inconvenient on a big screen. I suggest placing it at the top.

<img width="1374" height="1970" alt="image" src="https://github.com/user-attachments/assets/00cdee19-15cc-47c2-b69e-97299c038859" />
