### PR TITLE
An attempt to fix regressions

### DIFF
--- a/src/classes/FeatureProxy.js
+++ b/src/classes/FeatureProxy.js
@@ -3,7 +3,7 @@
  * Used to filter features
  */
 
-import { isSubsetOf, symmetricDifference } from '../util.js';
+import { symmetricDifference } from '../util.js';
 import AbstractFeature from './AbstractFeature.js';
 
 export default class FeatureProxy extends AbstractFeature {

--- a/src/util.js
+++ b/src/util.js
@@ -90,13 +90,13 @@ export function pick (obj, keys) {
 }
 
 export function groupBy (arr, fn) {
-	let grouped = {};
+	let grouped = new Map();
 	let isString = typeof fn === 'string';
 
 	for (let item of arr) {
 		let key = isString ? item[fn] : fn(item);
-		grouped[key] = grouped[key] || [];
-		grouped[key].push(item);
+		grouped.set(key, grouped.get(key) || []);
+		grouped.get(key).push(item);
 	}
 
 


### PR DESCRIPTION
Weirdly, the deploy preview is broken (due to a reference error: `Feature` is not defined), but everything works fine locally. 🤷‍♂️ Yes, we don't import the `Feature` class in `app.js`, but why is it not a problem in the local environment?! What am I missing?

<img width="562" height="171" alt="image" src="https://github.com/user-attachments/assets/d70be1df-0448-4184-9197-2ea7a2338c52" />

### Changes

- Remove nonexistent util function
- Judging from the rest of the code base, `groupBy` should return a map, not an object (we’re accessing `.size` and `.entries()` on it)